### PR TITLE
Add support for vintage OIDC issuer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add support for vintage OIDC issuer for migrated clusters
+
 ## [0.1.1] - 2024-05-09
 
 ### Fixed

--- a/helm/karpenter-crossplane-resources/templates/iam.yaml
+++ b/helm/karpenter-crossplane-resources/templates/iam.yaml
@@ -28,6 +28,20 @@ spec:
               }
             }
           }
+          {{- if .Values.internal.migration.irsaAdditionalDomain }}
+          , {
+            "Effect": "Allow",
+            "Principal": {
+              "Federated": "arn:{{.Values.awsPartition}}:iam::{{.Values.accountID}}:oidc-provider/{{.Values.internal.migration.irsaAdditionalDomain}}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+              "StringLike": {
+                "{{.Values.internal.migration.irsaAdditionalDomain}}:sub": "system:serviceaccount:*:*karpenter*"
+              }
+            }
+          }
+          {{- end }}
         ]
       }
     inlinePolicy:
@@ -109,6 +123,20 @@ spec:
               }
             }
           }
+          {{- if .Values.internal.migration.irsaAdditionalDomain }}
+          , {
+            "Effect": "Allow",
+            "Principal": {
+              "Federated": "arn:{{.Values.awsPartition}}:iam::{{.Values.accountID}}:oidc-provider/{{.Values.internal.migration.irsaAdditionalDomain}}"
+            },
+            "Action": "sts:AssumeRoleWithWebIdentity",
+            "Condition": {
+              "StringLike": {
+                "{{.Values.internal.migration.irsaAdditionalDomain}}:sub": "system:serviceaccount:*:*karpenter*"
+              }
+            }
+          }
+          {{- end }}
         ]
       }
     inlinePolicy:

--- a/helm/karpenter-crossplane-resources/templates/iam.yaml
+++ b/helm/karpenter-crossplane-resources/templates/iam.yaml
@@ -28,7 +28,7 @@ spec:
               }
             }
           }
-          {{- if .Values.internal.migration.irsaAdditionalDomain }}
+          {{- if ((.Values.internal).migration).irsaAdditionalDomain }}
           , {
             "Effect": "Allow",
             "Principal": {
@@ -123,7 +123,7 @@ spec:
               }
             }
           }
-          {{- if .Values.internal.migration.irsaAdditionalDomain }}
+          {{- if ((.Values.internal).migration).irsaAdditionalDomain }}
           , {
             "Effect": "Allow",
             "Principal": {

--- a/helm/karpenter-crossplane-resources/values.schema.json
+++ b/helm/karpenter-crossplane-resources/values.schema.json
@@ -44,6 +44,19 @@
         },
         "serviceType": {
             "type": "string"
+        },
+        "internal": {
+            "type": "object",
+            "properties": {
+                "migration": {
+                    "type": "object",
+                    "properties": {
+                        "irsaAdditionalDomain": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/helm/karpenter-crossplane-resources/values.yaml
+++ b/helm/karpenter-crossplane-resources/values.yaml
@@ -13,3 +13,7 @@ awsCluster:
 project:
   branch: "[[ .Branch ]]"
   commit: "[[ .SHA ]]"
+
+# internal:
+#   migration:
+#     irsaAdditionalDomain: ""


### PR DESCRIPTION
This is needed for vintage clusters migrated to CAPA, since they still use the vintage OIDC issuer for the time being.